### PR TITLE
Export solution pdf

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- You can now export the puzzle solution along with the puzzle using the `save()` method. Just specify `solution=True` after the path.
+    - If you are exporting a PDF then a second page will be added with the puzzled words highlighted in red (just like the `show(solution=True)` method)
+    - If you are exporting to CSV the puzzle solution will be included at the bottom of the csv below the answer key.
+
+### Changed
+- `save()` method now accepts the `solution` argument.
+- -c, --cheat cli option now works with the -o, --output option to include the puzzle solution within the output file (csv or pdf)
+- To clean things up a bit, `export_pdf_file()` and `export_csv_file()` now accept a WordSearch object as the main argument.
+
 ## [1.3.0]
 ### Added
 - -c, --cheat options for cli to show puzzle solution

--- a/README.md
+++ b/README.md
@@ -32,24 +32,26 @@ puzzle = WordSearch("dog, cat, pig, horse, donkey, turtle, goat, sheep")
 👀 Wanna see it? `print(puzzle)` or `puzzle.show()`
 
 ```
--------------------
-    WORD SEARCH
--------------------
-B T Z L K J C G E H
-X O N D G S W X M B
-W H P V O E H Q D N
-K G D I S G D C J G
-C J Y R G W F A H O
-M K O X N U K T F A
-C H T U R T L E I T
-D O N K E Y H C R M
-V R T U X G O L W H
-H J D G S H E E P Y
+-----------------------
+      WORD SEARCH
+-----------------------
+T L Q D O N K E Y K M P
+Z X R C V E J R S A H S
+C Y V I T I O Q U X C D
+A E P Z V C W J K D H P
+T V G O A T H R E O O A
+X Q P H S C I C S G R F
+U J I N I H S U H K S O
+F H G O Z J O A E D E I
+B Z S H S E D H E I X R
+H V P L U X Y B P Z U W
+M W B G Q T U R T L E T
+H X O U B M H S X W Q B
 
 Find these words: CAT, DOG, DONKEY, GOAT, HORSE, PIG, SHEEP, TURTLE
-* Words can go NE, E, SE, and S.
+* Words can go E, and S.
 
-Answer Key: CAT S @ (4, 8), DOG SE @ (2, 4), DONKEY E @ (8, 1), GOAT S @ (4, 10), HORSE NE @ (7, 2), PIG SE @ (3, 3), SHEEP E @ (10, 5), TURTLE E @ (7, 3)
+Answer Key: CAT S @ (2, 0), DOG S @ (3, 9), DONKEY E @ (0, 3), GOAT E @ (4, 2), HORSE S @ (3, 10), PIG S @ (5, 2), SHEEP S @ (5, 8), TURTLE E @ (10, 5)
 ```
 
 ℹ️ The output answer key uses a 1-based index as that's more familiar with non-programmers. First number is the row, second is the column. Directions are cardinal from first letter to last. The stored `puzzle.key` is 0-based.
@@ -73,20 +75,25 @@ or show just the hidden words `puzzle.show(solution=True)`.
 
 ```
 -----------------------
-       SOLUTION
+      WORD SEARCH
 -----------------------
-• • • • • • • C D H P •
-• • • • • • • A O O I •
-• • • • • D • T N R G •
-• • • • • O • • K S • •
-• • • • • G • • E E • •
-• • • • • • • G Y • • •
-• • • • • • • O • • • •
-• • S H E E P A • • • •
-• • • • T U R T L E • •
+• • • D O N K E Y • • •
 • • • • • • • • • • • •
+C • • • • • • • • • • •
+A • • • • • • • • D H •
+T • G O A T • • • O O •
+• • P • • • • • S G R •
+• • I • • • • • H • S •
+• • G • • • • • E • E •
+• • • • • • • • E • • •
+• • • • • • • • P • • •
+• • • • • T U R T L E •
 • • • • • • • • • • • •
-• • • • • • • • • • • •
+
+Find these words: CAT, DOG, DONKEY, GOAT, HORSE, PIG, SHEEP, TURTLE
+* Words can go E, and S.
+
+Answer Key: CAT S @ (2, 0), DOG S @ (3, 9), DONKEY E @ (0, 3), GOAT E @ (4, 2), HORSE S @ (3, 10), PIG S @ (5, 2), SHEEP S @ (5, 8), TURTLE E @ (10, 5)
 ```
 
 🍰 Too easy? Up the difficulty level with `puzzle.level = 3`.
@@ -95,24 +102,23 @@ or show just the hidden words `puzzle.show(solution=True)`.
 -----------------------
       WORD SEARCH
 -----------------------
-P X Y F L S O C Z R G R
-H M S G O A T Y N T J N
-G E C R S H U B O K X Y
-T N Z I O C P H Y L W H
-A J W R T M I E K T Y D
-C X S Z A S G Y E U C E
-P E C N F X E L D H B L
-V T J I G K R K O M S T
-L C H Y N H I N G Z W R
-K Z A O F G E Y E N V U
-R X D T V Y S U P F J T
-C A M R U R P H E X K D
+J V W N B Y E K N O D U
+G E B D F N H O R S E H
+M I C K G Y F I D C P D
+V H W A V H M Y O B G I
+G O A T T C F U A S H K
+X H U W K V O Y G V B O
+G B Q A M Z X W O Z Y N
+T M D P C A S B D E W E
+L Y I E R W X G I P U C
+C H U E C N Q C J L W O
+F S X H G I V I P F A N
+B J D S F M E L T R U T
 
 Find these words: CAT, DOG, DONKEY, GOAT, HORSE, PIG, SHEEP, TURTLE
-
 * Words can go N, NE, E, SE, S, SW, W, and NW.
 
-Answer Key: CAT N @ (6, 1), DOG S @ (7, 9), DONKEY NE @ (11, 3), GOAT E @ (2, 4), HORSE SW @ (3, 6), PIG S @ (4, 7), SHEEP NW @ (8, 11), TURTLE N @ (11, 12)
+Answer Key: CAT SE @ (2, 2), DOG N @ (7, 8), DONKEY W @ (0, 10), GOAT E @ (4, 0), HORSE E @ (1, 6), PIG W @ (8, 9), SHEEP N @ (11, 3), TURTLE W @ (11, 11)
 ```
 
 😓 Too hard? Go the easy route with `puzzle.level = 1`.
@@ -149,30 +155,46 @@ The difficulty level controls whether words can go forward or backward, the card
 
 ### Puzzle Size
 
-By default, the puzzle (characters) size is determined by the amount of words provided and the difficulty level. Need a puzzle an exact size, override the default with `puzzle.size = x` (25 >= integer >= 10). All puzzles are square so size` will be the width and height.
+By default, the puzzle (characters) size is determined by the amount of words provided and the difficulty level. Need a puzzle an exact size, override the default with `puzzle.size = x` (25 >= integer >= 10). All puzzles are square so size will be the width and height.
+
+```python
+puzzle.size = 30
+ValueError: Puzzle size must be >= 10 and <= 25
+puzzle.size = 20
+puzzle.show()
+```
+
+Puzzles are limited to 25 characters wide so that everything fits nicely on a US Letter or A4 sized sheet of paper.
 
 ```
------------------------
-      WORD SEARCH
------------------------
-T M Y T U R T L E T O A
-Y B V D L S A J X C K G
-J Z K A T B N K U N R L
-K U F V R K C G D H J T
-P Q P I G P N V O Z G S
-X C G J N Y A B N F O H
-G A X L C G T J K U A E
-O T R B H E O X E L T E
-G A D Y M S C U Y Q K P
-R X O N K Z H O R S E C
-Y Q G H G F M U K L Z B
-H W T C P W S X N U D N
+---------------------------------------
+              WORD SEARCH
+---------------------------------------
+T K U D Q X Z W J N K F N W C J K A M R
+H A M H R O S C M E H G C K D R I L B O
+I N S L X I D I V Z P N Q B S Q X P N V
+Q U Z M V M P N P A C W X L F T S B X J
+E V W H O R S E R L I E N R V W A Z S Q
+N A K P M N F D F W U O F E F G T C F D
+J X W N H B O K X P J I M A H L M Q W L
+R Q S R E Z Y N C Q C N E I Z X Y C S N
+M T H M V I S H E E P H F H J N D W B M
+P B U F S M B Y O L I U B E R W Q I D K
+J Z Y E J U X E C V E H C L M U P M W G
+S N X M T F T K R I N G W T D C E H V N
+B V Z N O K H N H V Z B P R V N L G M O
+R M G E L B P O X U R T M U P Y A D I U
+Y V T O I Q I D Z G A N S T K E M F E P
+U D M K E V B H R O E Q O N M Z V Q B Y
+R Q C N U R J V G S L J M R X F B R T J
+Z F G L D W U R Z Y P W U O A H O X P Q
+R O U P S T I O H Q S M X F S K P Z C D
+D M K J M P E R X W G Z A V N F X B T J
 
 Find these words: CAT, DOG, DONKEY, GOAT, HORSE, PIG, SHEEP, TURTLE
+* Words can go N, NE, E, SE, S, SW, W, and NW.
 
-* Words can go E, and S.
-
-Answer Key: CAT S @ (6, 2), DOG S @ (9, 3), DONKEY S @ (4, 9), GOAT S @ (5, 11), HORSE E @ (10, 7), PIG E @ (5, 3), SHEEP S @ (5, 12), TURTLE E @ (1, 4)
+Answer Key: CAT NW @ (5, 17), DOG NE @ (19, 0), DONKEY N @ (14, 7), GOAT NE @ (16, 8), HORSE E @ (4, 3), PIG NW @ (14, 19), SHEEP E @ (8, 6), TURTLE N @ (14, 13)
 ```
 
 ⚠️ All provided words may not fit a specified puzzle size!
@@ -232,9 +254,9 @@ Word-Search-Generator works in your terminal too! 🙌
 
 ```
 $ word-search -h
-usage: word-search [-h] [-r RANDOM] [-l {1,2,3}] [-s SIZE] [-o OUTPUT] [words ...]
+usage: word-search [-h] [-r RANDOM] [-l {1,2,3}] [-s SIZE] [-c] [-o OUTPUT] [--version] [words ...]
 
-Generate Word Search Puzzles!
+Generate Word Search Puzzles! (Version 1.3.0)
 
 positional arguments:
   words                 Words to include in the puzzle
@@ -246,10 +268,13 @@ options:
   -l {1,2,3}, --level {1,2,3}
                         Difficulty level (1) beginner, (2) intermediate, (3) expert
   -s SIZE, --size SIZE  Puzzle size >=10 and <=25
+  -c, --cheat           Show the puzzle solution or include it within the `-o, --output` file.
   -o OUTPUT, --output OUTPUT
-                        Output path for saved puzzle. Specify export type by appending '.pdf' or '.csv' to your path (defaults to PDF)
+                        Output path for saved puzzle. Specify export type by appending '.pdf' or '.csv' to your path
+                        (defaults to PDF)
+  --version             show program's version number and exit
 
-Copyright 2021 Josh Duncan (joshbduncan.com)
+Copyright 2022 Josh Duncan (joshbduncan.com)
 ```
 
 💻 Generate a puzzle.
@@ -264,13 +289,13 @@ Copyright 2021 Josh Duncan (joshbduncan.com)
 
     $ word-search -r 10
 
-💻 Generate a puzzle and **save as a pdf**.
-
-    $ word-search works, in, the, terminal, too -o ~/Desktop/puzzle.pdf
-
 💻 Generate a puzzle and **save as a csv**.
 
     $ word-search works, in, the, terminal, too -o puzzle.csv
+
+💻 Generate a puzzle and **save as a pdf** with the solution puzzle included.
+
+    $ word-search works, in, the, terminal, too -o ~/Desktop/puzzle.pdf -c
 
 ℹ️ You can also use words from a file...
 
@@ -289,4 +314,6 @@ Puzzle saved: ~/.../words-50.txt.pdf
 
 ## Resources
 
--   [PyPi](https://pypi.python.org/pypi/word-search-generator)
+- [PyPi](https://pypi.python.org/pypi/word-search-generator)
+- [PyFPDF/fpdf2: Simple PDF generation for Python](https://github.com/PyFPDF/fpdf2)
+- [Word search - Wikipedia](https://en.wikipedia.org/wiki/Word_search)

--- a/src/word_search_generator/__init__.py
+++ b/src/word_search_generator/__init__.py
@@ -174,7 +174,7 @@ class WordSearch:
             )
         )
 
-    def save(self, path: Union[str, Path]) -> str:
+    def save(self, path: Union[str, Path], solution) -> str:
         """Save the current puzzle to a file.
 
         Args:
@@ -191,10 +191,15 @@ class WordSearch:
         # validate export path
         path = export.validate_path(path)
         # write the file
+        x = self.solution[:]
+        for row in range(len(x)):
+            for col in range(len(x[row])):
+                if x[row][col] == "•":
+                    x[row][col] = " "
         if ftype == "csv":
-            saved_file = export.write_csv_file(path, self.puzzle, self.key, self.level)
+            saved_file = export.write_csv_file(path, x, self.key, self.level)
         else:
-            saved_file = export.write_pdf_file(path, self.puzzle, self.key, self.level)
+            saved_file = export.write_pdf_file(path, x, self.key, self.level)
         # return saved file path
         return str(saved_file)
 

--- a/src/word_search_generator/__init__.py
+++ b/src/word_search_generator/__init__.py
@@ -174,11 +174,13 @@ class WordSearch:
             )
         )
 
-    def save(self, path: Union[str, Path], solution) -> str:
+    def save(self, path: Union[str, Path], solution: bool = False) -> str:
         """Save the current puzzle to a file.
 
         Args:
-            path (Union[str, Path]): A file save path.
+            path (Union[str, Path]): A file save path
+            solution (bool, optional): Include solution with the saved file.
+                                       Defaults to False.
 
         Returns:
             str: Final save path of the file.
@@ -191,15 +193,10 @@ class WordSearch:
         # validate export path
         path = export.validate_path(path)
         # write the file
-        x = self.solution[:]
-        for row in range(len(x)):
-            for col in range(len(x[row])):
-                if x[row][col] == "•":
-                    x[row][col] = " "
         if ftype == "csv":
-            saved_file = export.write_csv_file(path, x, self.key, self.level)
+            saved_file = export.write_csv_file(path, self, solution)
         else:
-            saved_file = export.write_pdf_file(path, x, self.key, self.level)
+            saved_file = export.write_pdf_file(path, self, solution)
         # return saved file path
         return str(saved_file)
 

--- a/src/word_search_generator/cli.py
+++ b/src/word_search_generator/cli.py
@@ -80,8 +80,8 @@ def main(
     parser.add_argument(
         "-c",
         "--cheat",
-        action=argparse.BooleanOptionalAction,
-        help="Highlight all hidden puzzle words.",
+        action="store_true",
+        help="Show the puzzle solution or include it within the `-o, --output` file.",
     )
     parser.add_argument(
         "-o",
@@ -90,7 +90,6 @@ def main(
         help="Output path for saved puzzle. Specify export type by appending "
         "'.pdf' or '.csv' to your path (defaults to PDF)",
     )
-
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
     )
@@ -104,17 +103,14 @@ def main(
     else:
         words = ",".join(args.words)
 
-    # check to see if solution should be highlighted
-    cheat = True if args.cheat else False
-
     # create a new puzzle object from provided arguments
     puzzle = WordSearch(words, level=args.level, size=args.size)
     # show the result
     if args.output:
-        foutput = puzzle.save(path=args.output)
+        foutput = puzzle.save(path=args.output, solution=args.cheat)
         print(f"Puzzle saved: {foutput}")
     else:
-        puzzle.show(solution=cheat)
+        puzzle.show(solution=args.cheat)
 
     return 0
 

--- a/src/word_search_generator/export.py
+++ b/src/word_search_generator/export.py
@@ -1,18 +1,22 @@
+from __future__ import annotations
+
 import csv
 from pathlib import Path
-from typing import Union
+from typing import TYPE_CHECKING
 
 from fpdf import FPDF
 
 from word_search_generator import config, utils
-from word_search_generator.types import Key, Puzzle
+
+if TYPE_CHECKING:
+    from word_search_generator import WordSearch
 
 
-def validate_path(path: Union[str, Path]) -> Path:
+def validate_path(path: str | Path) -> Path:
     """Validate the save path.
 
     Args:
-        path (Union[str, Path]): Path to save location.
+        path (str | Path): Path to save location.
 
     Raises:
         FileExistsError: The output path already exists as a file.
@@ -31,22 +35,13 @@ def validate_path(path: Union[str, Path]) -> Path:
     return path
 
 
-def write_csv_file(
-    path: Path,
-    puzzle: Puzzle,
-    key: Key,
-    level: int,
-) -> Path:
+def write_csv_file(path: Path, puzzle: WordSearch, solution: bool = False) -> Path:
     """Write current puzzle to CSV format at `path`.
 
     Args:
         path (Path): Path to write the file to.
-        puzzle (Puzzle): Current Word Search puzzle.
-        key (Key): Puzzle answer key.
-        level (int): Puzzle level.
-
-    Raises:
-        OSError: File could not be written.
+        puzzle (Type[WordSearch]): Current Word Search puzzle.
+        solution (bool, optional): Include the puzzle solution. Defaults to False.
 
     Returns:
         Path: Final save path.
@@ -57,63 +52,100 @@ def write_csv_file(
             f, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
         )
         f_writer.writerow(["WORD SEARCH"])
-        for row in puzzle:
+        for row in puzzle.puzzle:
             f_writer.writerow(row)
         f_writer.writerow([""])
         f_writer.writerow(["Word List:"])
-        f_writer.writerow([k for k in sorted(key.keys())])
-        f_writer.writerow([f"* Words can go {utils.get_level_dirs_str(level)}."])
+        f_writer.writerow([k for k in sorted(puzzle.key.keys())])
+        f_writer.writerow([f"* Words can go {utils.get_level_dirs_str(puzzle.level)}."])
         f_writer.writerow([""])
         f_writer.writerow(["Answer Key:"])
-        f_writer.writerow(utils.get_answer_key_list(key))
+        f_writer.writerow(utils.get_answer_key_list(puzzle.key))
+        if solution:
+            f_writer.writerow([""])
+            f_writer.writerow(["SOLUTION"])
+            for row in puzzle.solution:
+                f_writer.writerow([c if c else " " for c in row])
     return path.absolute()
 
 
-def write_pdf_file(
-    path: Path,
-    puzzle: Puzzle,
-    key: Key,
-    level: int,
-) -> Path:
+def write_pdf_file(path: Path, puzzle: WordSearch, solution: bool = False) -> Path:
     """Write current puzzle to PDF format at `path`.
 
     Args:
         path (Path): Path to write the file to.
-        puzzle (Puzzle): Current Word Search puzzle.
-        key (Key): Puzzle answer key.
-        level (int): Puzzle level.
+        puzzle (Type[WordSearch]): Current Word Search puzzle.
+        solution (bool, optional): Include the puzzle solution. Defaults to False.
 
     Raises:
         OSError: File could not be written.
 
     Returns:
-        Path: Final save path.
+        Path: Final save path.s
     """
+
     # setup the PDF document
     pdf = FPDF(orientation="P", unit="in", format="Letter")
     pdf.set_author(config.pdf_author)
     pdf.set_creator(config.pdf_creator)
     pdf.set_title(config.pdf_title)
+    pdf.set_line_width(pdf.line_width * 2)
+
+    # draw initial puzzle page
+    pdf = draw_puzzle_page(pdf, puzzle, False)
+
+    # add puzzle solution page if requested
+    if solution:
+        pdf = draw_puzzle_page(pdf, puzzle, True)
+
+    # write the final PDF to the filesystem
+    try:
+        pdf.output(path)
+    except OSError:
+        raise OSError(f"File could not be saved to '{path}'.")
+    return path.absolute()
+
+
+def draw_puzzle_page(pdf: FPDF, puzzle: WordSearch, solution: bool = False) -> FPDF:
+    """Draw the puzzle information on a FPDF PDF page.
+
+    Args:
+        pdf (FPDF): FPDF PDF document.
+        puzzle (Type[WordSearch]): Current Word Search puzzle.
+        solution (bool, optional): Highlight the puzzle solution. Defaults to False.
+
+    Returns:
+        FPDF: FPDF PDF with drawn puzzle page.
+    """
+
+    # add a new page and setup the margins
     pdf.add_page()
     pdf.set_margin(0.5)
 
     # insert the title
+    title = "WORD SEARCH" if not solution else "WORD SEARCH (SOLUTION)"
     pdf.set_font("Helvetica", "B", config.pdf_title_font_size)
-    pdf.cell(pdf.epw, 0.25, "WORD SEARCH", ln=2, align="C", center=True)
+    pdf.cell(pdf.epw, 0.25, title, ln=2, align="C", center=True)
     pdf.ln(0.375)
 
     # calculate the puzzle size and letter font size
     pdf.set_left_margin(0.75)
-    gsize = 7 / len(puzzle)
+    gsize = 7 / len(puzzle.puzzle)
     gmargin = 0.6875 if gsize > 36 else 0.75
     font_size = 72 * gsize * gmargin
     info_font_size = font_size if font_size < 18 else 18
     pdf.set_font_size(font_size)
 
     # draw the puzzle
-    for row in puzzle:
-        for char in row:
-            pdf.multi_cell(gsize, gsize, char, align="C", ln=3)
+    for r, row in enumerate(puzzle.puzzle):
+        for c, char in enumerate(row):
+            # draw a border around correct letters if solution was requested
+            if solution and puzzle.solution[r][c]:
+                pdf.set_text_color(255, 0, 0)
+                pdf.multi_cell(gsize, gsize, char, align="C", ln=3)
+                pdf.set_text_color(0, 0, 0)
+            else:
+                pdf.multi_cell(gsize, gsize, char, align="C", ln=3)
         pdf.ln(gsize)
     pdf.ln(0.25)
 
@@ -121,7 +153,7 @@ def write_pdf_file(
     pdf.set_font("Helvetica", "BU", size=info_font_size)
     pdf.cell(
         pdf.epw,
-        txt=f"Find words going {utils.get_level_dirs_str(level)}:",
+        txt=f"Find words going {utils.get_level_dirs_str(puzzle.level)}:",
         align="C",
         ln=2,
     )
@@ -133,7 +165,7 @@ def write_pdf_file(
     pdf.multi_cell(
         pdf.epw,
         info_font_size / 72 * 1.125,
-        utils.get_word_list_str(key),
+        utils.get_word_list_str(puzzle.key),
         align="C",
         ln=2,
     )
@@ -146,11 +178,6 @@ def write_pdf_file(
         pdf.set_xy(pdf.epw - pdf.epw, 0)
         pdf.set_margin(0.25)
         pdf.set_font("Helvetica", size=config.pdf_key_font_size)
-        pdf.write(txt="Answer Key: " + utils.get_answer_key_str(key))
+        pdf.write(txt="Answer Key: " + utils.get_answer_key_str(puzzle.key))
 
-    # write the final PDF to the filesystem
-    try:
-        pdf.output(path)
-    except OSError:
-        raise OSError(f"File could not be saved to '{path}'.")
-    return path.absolute()
+    return pdf

--- a/src/word_search_generator/generate.py
+++ b/src/word_search_generator/generate.py
@@ -89,19 +89,19 @@ def capture_all_paths_from_position(
     # follow each direction and capture all characters in that path
     for i, (direction, (rmove, cmove)) in enumerate(config.dir_moves.items()):
         row, col = position
-        string = ""
+        chars: list[str] = []
         for _ in range(radius):
-            string += puzzle[row][col]
+            chars.append(puzzle[row][col])
             row += rmove
             col += cmove
             if out_of_bounds(puzzle_size, puzzle_size, (row, col)):
                 break
-        # add the captured string of characters to the correct
-        # spot in the paths lists, and reverse if needed
+            # add the captured string of characters to the correct
+            # spot in the paths lists, and reverse if needed
         if direction in ["N", "NW", "W", "SW"]:
-            paths[i % 4][0] = string[1:][::-1]
+            paths[i % 4][0] = "".join(chars[1:][::-1])
         else:
-            paths[i % 4][1] = string[1:]
+            paths[i % 4][1] = "".join(chars[1:])
     return paths
 
 
@@ -161,7 +161,7 @@ def test_a_fit(
     for char in word:
         rmove, cmove = config.dir_moves[direction]
         # if the current puzzle space is empty or if letters match
-        if puzzle[row][col] == "•" or puzzle[row][col] == char:
+        if puzzle[row][col] == "" or puzzle[row][col] == char:
             coordinates.append((row, col))
         else:
             return []
@@ -215,7 +215,7 @@ def fill_words(words: set[str], level: int, size: int) -> tuple[Puzzle, Key]:
 
     # calculate the puzzle size and setup a new empty puzzle
     size = calc_puzzle_size(words, level, size)
-    puzzle = [["•"] * size for _ in range(size)]
+    puzzle = [[""] * size for _ in range(size)]
     key: dict[str, KeyInfo] = {}
 
     # try to place each word on the puzzle
@@ -305,7 +305,7 @@ def fill_blanks(puzzle: Puzzle, placed_words: list[str]) -> Puzzle:
     for row in range(len(work_puzzle)):
         for col in range(len(work_puzzle[0])):
             # if the current spot is empty fill with random character
-            if work_puzzle[row][col] == "•":
+            if work_puzzle[row][col] == "":
                 while True:
                     random_char = random.choice(ALPHABET)
                     if no_matching_neighbors(work_puzzle, random_char, (row, col)):

--- a/src/word_search_generator/utils.py
+++ b/src/word_search_generator/utils.py
@@ -79,10 +79,10 @@ def highlight_solution(puzzle: Puzzle, solution: Puzzle) -> Puzzle:
 
     Args:
         puzzle (Puzzle): The current puzzle state.
-        solution (Puzzle): The current puzzle solition.
+        solution (Puzzle): The current puzzle solution.
 
     Returns:
-        str: The current puzzle as a string with higilighting.
+        str: The current puzzle as a string with highlighting.
     """
     output = []
     for r, line in enumerate(puzzle):

--- a/src/word_search_generator/utils.py
+++ b/src/word_search_generator/utils.py
@@ -89,7 +89,7 @@ def highlight_solution(puzzle: Puzzle, solution: Puzzle) -> Puzzle:
         line_chars = []
         # check to see if character if part of a puzzle word
         for c, char in enumerate(line):
-            if solution[r][c] != "•":
+            if solution[r][c]:
                 line_chars.append(f"\u001b[1m\u001b[31m{char}\u001b[0m")
             else:
                 line_chars.append(f"{char}")

--- a/tests/test_WordSearch.py
+++ b/tests/test_WordSearch.py
@@ -146,7 +146,7 @@ def test_puzzle_solution():
     print(puzzle.solution)
     puzzle_chars = set([char for line in puzzle.solution for char in line])
     key_chars = set([char for word in puzzle.key for char in word])
-    key_chars.add("•")
+    key_chars.add("")
     assert puzzle_chars == key_chars
 
 
@@ -239,4 +239,4 @@ def test_for_empty_spaces():
         words = get_random_words(10)
         p = WordSearch(words, level=3)
         flat = [item for sublist in p.puzzle for item in sublist]
-        assert "•" not in flat
+        assert p.size * p.size == len(flat)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -31,6 +31,26 @@ def test_export_pdf_puzzles(tmp_path):
     assert pages == {1}
 
 
+def test_export_pdf_puzzle_with_solution(tmp_path):
+    """Make sure a puzzle exported with the solution is 2 pages."""
+    sizes = [s for s in range(config.min_puzzle_size, config.max_puzzle_size)]
+    puzzles = []
+    pages = set()
+    for size in sizes:
+        words = utils.get_random_words(
+            random.randint(config.min_puzzle_words, config.max_puzzle_words)
+        )
+        level = random.randint(1, 3)
+        puzzle = WordSearch(words, level=level, size=size)
+        path = Path.joinpath(tmp_path, f"{uuid.uuid4()}.pdf")
+        puzzle.save(path, solution=True)
+        puzzles.append(path)
+    for p in puzzles:
+        pdf = PdfFileReader(open(p, "rb"))
+        pages.add(pdf.getNumPages())
+    assert pages == {2}
+
+
 def test_export_overwrite_file_error(tmp_path):
     """Try to export a puzzle with the name of a file that is already present."""
     path = Path.joinpath(tmp_path, "test.pdf")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -4,11 +4,11 @@ from word_search_generator.generate import check_for_dupes_at_position
 def test_dupe_at_position_1():
     placed_words = ["BAT", "CAT", "RAT"]
     puzzle = [
-        ["B", "•", "•", "•", "R"],
-        ["•", "A", "•", "•", "A"],
-        ["•", "•", "T", "•", "T"],
-        ["•", "•", "•", "•", "•"],
-        ["C", "A", "T", "•", "B"],
+        ["B", "", "", "", "R"],
+        ["", "A", "", "", "A"],
+        ["", "", "T", "", "T"],
+        ["", "", "", "", ""],
+        ["C", "A", "T", "", "B"],
     ]
     check = check_for_dupes_at_position(puzzle, "A", (3, 3), placed_words)
     print(f"{check=}")
@@ -18,11 +18,11 @@ def test_dupe_at_position_1():
 def test_dupe_at_position_2():
     placed_words = ["BAT", "CAT", "RAT"]
     puzzle = [
-        ["B", "•", "•", "•", "R"],
-        ["•", "A", "•", "•", "A"],
-        ["•", "•", "T", "•", "T"],
-        ["•", "•", "•", "•", "•"],
-        ["C", "A", "T", "•", "B"],
+        ["B", "", "", "", "R"],
+        ["", "A", "", "", "A"],
+        ["", "", "T", "", "T"],
+        ["", "", "", "", ""],
+        ["C", "A", "T", "", "B"],
     ]
     check = check_for_dupes_at_position(puzzle, "A", (1, 3), placed_words)
     print(f"{check=}")


### PR DESCRIPTION
Additional functionality in response to issues #14 and #15.

## Added
- You can now export the puzzle solution along with the puzzle using the `save()` method. Just specify `solution=True` after the path.
    - If you are exporting a PDF then a second page will be added with the puzzled words highlighted in red (just like the `show(solution=True)` method)
    - If you are exporting to CSV the puzzle solution will be included at the bottom of the csv below the answer key.

## Changed
- `save()` method now accepts the `solution` argument.
- -c, --cheat cli option now works with the -o, --output option to include the puzzle solution within the output file (csv or pdf)
- To clean things up a bit, `export_pdf_file()` and `export_csv_file()` now accept a WordSearch object as the main argument.