### PR TITLE
Add __len__ to Word

### DIFF
--- a/src/word_search_generator/config.py
+++ b/src/word_search_generator/config.py
@@ -13,6 +13,7 @@ INACTIVE = "#"
 
 # puzzle difficulty levels
 level_dirs = {
+    -1: set(),  # no valid directions
     1: {  # right or down
         Direction.E,
         Direction.S,

--- a/src/word_search_generator/config.py
+++ b/src/word_search_generator/config.py
@@ -12,7 +12,7 @@ ACTIVE = "*"
 INACTIVE = "#"
 
 # puzzle difficulty levels
-level_dirs = {
+level_dirs: dict[int, set[Direction]] = {
     -1: set(),  # no valid directions
     1: {  # right or down
         Direction.E,

--- a/src/word_search_generator/word.py
+++ b/src/word_search_generator/word.py
@@ -218,6 +218,11 @@ class Word:
         self.coordinates = []
         self.direction = None
 
+    def __bool__(self) -> bool:
+        """Returns the truthiness of a word.
+        Should always return true, except for the null word."""
+        return bool(self.text)
+
     def __eq__(self, __o: object) -> bool:
         """Returns True if both instances have the same text."""
         if not isinstance(__o, Word):
@@ -240,3 +245,5 @@ class Word:
 
 
 WordSet: TypeAlias = set[Word]
+# in the future, add allowed_directions = set() and priority = 999
+NULL_WORD = Word("", True)

--- a/src/word_search_generator/word.py
+++ b/src/word_search_generator/word.py
@@ -61,7 +61,7 @@ class Word:
         secret: bool = False,
     ) -> None:
         """Initialize a Word Search puzzle Word."""
-        self.text = text.upper()
+        self.text = text.upper().strip()
         self.start_row: int | None = None
         self.start_column: int | None = None
         self.coordinates: list[tuple[int, int]] = []
@@ -227,6 +227,10 @@ class Word:
     def __hash__(self) -> int:
         """Returns the hashes value of the word text."""
         return hash(self.text)
+
+    def __len__(self) -> int:
+        """Returns the length of the word text."""
+        return len(self.text)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}('{self.text}', " + f"{self.secret})"

--- a/tests/test_Word.py
+++ b/tests/test_Word.py
@@ -60,3 +60,8 @@ def test_empty_key_string():
 def test_offset_empty_position_xy():
     w = Word("test")
     assert w.offset_position_xy(((0, 0), (10, 10))) == Position(None, None)
+
+
+def test_word_length():
+    w = Word("test")
+    assert len(w) == 4

--- a/tests/test_Word.py
+++ b/tests/test_Word.py
@@ -65,3 +65,13 @@ def test_offset_empty_position_xy():
 def test_word_length():
     w = Word("test")
     assert len(w) == 4
+
+
+def test_word_bool_true():
+    w = Word("test")
+    assert w
+
+
+def test_word_bool_false():
+    w = Word("")
+    assert not w


### PR DESCRIPTION
Also `.strip()`s the incoming text in preparation for outside users to create Words directly.  If this is a performance hit or if we should leave the opportunity for future users to pad their Words with whitespace, let me know and I'll resubmit without this change.

Addresses a trivial component of #51. 