### PR TITLE
Move allowed_directions to the Word object & give them priorities

### DIFF
--- a/src/word_search_generator/core/directions.py
+++ b/src/word_search_generator/core/directions.py
@@ -70,6 +70,7 @@ def invert_ds(ds: DirectionSet, freeze: bool = False) -> DirectionSet:
 def reverse_directions(
     ds: Iterable[Direction], output_type: Callable[..., Iterable[Direction]] = set
 ) -> Iterable[Direction]:
+    """Makes all the directions in the Iterable point the other way."""
     return output_type(d.opposite for d in ds)
 
 

--- a/src/word_search_generator/core/directions.py
+++ b/src/word_search_generator/core/directions.py
@@ -47,6 +47,7 @@ class Direction(Enum):
 
 
 DirectionSet: TypeAlias = set[Direction] | frozenset[Direction]
+DirectionList: TypeAlias = list[Direction]
 _ALL_DIRECTIONS = frozenset(
     {
         Direction.N,

--- a/src/word_search_generator/core/game.py
+++ b/src/word_search_generator/core/game.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from typing import Iterable, Sized, TypeAlias
 
 from ..core.formatter import Formatter
-from ..core.generator import Generator
+from ..core.generator import Generator, Puzzle
 from ..mask import CompoundMask, Mask
 from ..utils import BoundingBox, find_bounding_box, limit
 from .directions import LEVEL_DIRS, Direction, DirectionSet
 from .validator import Validator
-from .word import KeyInfo, KeyInfoJson, Word, WordSet
+from .word import KeyInfo, KeyInfoJson, Word, WordSet, make_many_words
 
 
 class EmptyPuzzleError(Exception):
@@ -61,7 +61,6 @@ class MissingWordError(Exception):
     pass
 
 
-Puzzle: TypeAlias = list[list[str]]
 Key: TypeAlias = dict[str, KeyInfo]
 KeyJson: TypeAlias = dict[str, KeyInfoJson]
 
@@ -484,7 +483,7 @@ class Game:
                 "Words must be a string separated by spaces, commas, or new lines"
             )
         return limit(
-            Word.bulk_create(
+            make_many_words(
                 words,
                 allowed_directions if allowed_directions else self.DEFAULT_DIRECTIONS,
                 secret,

--- a/src/word_search_generator/core/game.py
+++ b/src/word_search_generator/core/game.py
@@ -8,7 +8,7 @@ from typing import Iterable, Sized, TypeAlias
 from ..core.formatter import Formatter
 from ..core.generator import Generator
 from ..mask import CompoundMask, Mask
-from ..utils import BoundingBox, find_bounding_box
+from ..utils import BoundingBox, find_bounding_box, limit
 from .directions import LEVEL_DIRS, Direction, DirectionSet
 from .validator import Validator
 from .word import KeyInfo, KeyInfoJson, Word
@@ -485,23 +485,23 @@ class Game:
             raise TypeError(
                 "Words must be a string separated by spaces, commas, or new lines"
             )
-        word_set = {
-            Word(
-                w,
-                secret,
-                self.DEFAULT_DIRECTIONS
-                if allowed_directions is None
-                else allowed_directions,
-                self.DEFAULT_SECRET_PRIORITY if secret else self.DEFAULT_WORD_PRIORITY,
-            )
-            for w in ",".join(words.replace("\n", ",").split(" ")).split(",")
-            if w.strip()
-        }
-        # length check at the end in case duplicates shrink a too-long list to fit
-        if len(word_set) <= self.MAX_PUZZLE_WORDS:
-            return word_set  # all done!
-        # trim to MAX_PUZZLE_WORDS
-        return set(random.sample(list(word_set), self.MAX_PUZZLE_WORDS))
+        return limit(
+            {
+                Word(
+                    w,
+                    secret,
+                    self.DEFAULT_DIRECTIONS
+                    if allowed_directions is None
+                    else allowed_directions,
+                    self.DEFAULT_SECRET_PRIORITY
+                    if secret
+                    else self.DEFAULT_WORD_PRIORITY,
+                )
+                for w in ",".join(words.replace("\n", ",").split(" ")).split(",")
+                if w.strip()
+            },
+            self.MAX_PUZZLE_WORDS,
+        )
 
     _cleanup_input = _process_input  # alias, perhaps refactor later
 

--- a/src/word_search_generator/core/game.py
+++ b/src/word_search_generator/core/game.py
@@ -7,7 +7,7 @@ from ..core.formatter import Formatter
 from ..core.generator import Generator
 from ..mask import CompoundMask, Mask
 from ..utils import BoundingBox, find_bounding_box
-from .directions import LEVEL_DIRS, Direction
+from .directions import LEVEL_DIRS, Direction, DirectionSet
 from .validator import Validator
 from .word import KeyInfo, KeyInfoJson, Word
 
@@ -61,7 +61,6 @@ class MissingWordError(Exception):
 
 
 Puzzle: TypeAlias = list[list[str]]
-DirectionSet: TypeAlias = set[Direction]
 Key: TypeAlias = dict[str, KeyInfo]
 KeyJson: TypeAlias = dict[str, KeyInfoJson]
 WordSet: TypeAlias = set[Word]

--- a/src/word_search_generator/core/game.py
+++ b/src/word_search_generator/core/game.py
@@ -1,6 +1,5 @@
 import contextlib
 import json
-import random
 from math import log2
 from pathlib import Path
 from typing import Iterable, Sized, TypeAlias
@@ -11,7 +10,7 @@ from ..mask import CompoundMask, Mask
 from ..utils import BoundingBox, find_bounding_box, limit
 from .directions import LEVEL_DIRS, Direction, DirectionSet
 from .validator import Validator
-from .word import KeyInfo, KeyInfoJson, Word
+from .word import KeyInfo, KeyInfoJson, Word, WordSet
 
 
 class EmptyPuzzleError(Exception):
@@ -65,7 +64,6 @@ class MissingWordError(Exception):
 Puzzle: TypeAlias = list[list[str]]
 Key: TypeAlias = dict[str, KeyInfo]
 KeyJson: TypeAlias = dict[str, KeyInfoJson]
-WordSet: TypeAlias = set[Word]
 
 
 class Game:
@@ -486,20 +484,12 @@ class Game:
                 "Words must be a string separated by spaces, commas, or new lines"
             )
         return limit(
-            {
-                Word(
-                    w,
-                    secret,
-                    self.DEFAULT_DIRECTIONS
-                    if allowed_directions is None
-                    else allowed_directions,
-                    self.DEFAULT_SECRET_PRIORITY
-                    if secret
-                    else self.DEFAULT_WORD_PRIORITY,
-                )
-                for w in ",".join(words.replace("\n", ",").split(" ")).split(",")
-                if w.strip()
-            },
+            Word.bulk_create(
+                words,
+                allowed_directions if allowed_directions else self.DEFAULT_DIRECTIONS,
+                secret,
+                self.DEFAULT_SECRET_PRIORITY if secret else self.DEFAULT_WORD_PRIORITY,
+            ),
             self.MAX_PUZZLE_WORDS,
         )
 

--- a/src/word_search_generator/core/generator.py
+++ b/src/word_search_generator/core/generator.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import string
 from abc import ABC, abstractmethod
-from functools import wraps
 from typing import TYPE_CHECKING, Iterable, TypeAlias
 
 if TYPE_CHECKING:  # pragma: no cover
     from . import GameType
-    from .game import Puzzle
+
+from ..utils import Puzzle
 
 
 Fit: TypeAlias = tuple[str, list[tuple[int, int]]]
@@ -28,29 +28,6 @@ class EmptyAlphabetError(Exception):
 
 class WordFitError(Exception):
     pass
-
-
-def retry(retries: int = 1000):
-    """Custom retry decorator for retrying a function `retries` times.
-
-    Args:
-        retries (int, optional): Retry attempts. Defaults to 1000.
-    """
-
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            attempt = 0
-            while attempt < retries:
-                try:
-                    return func(*args, **kwargs)
-                except Exception:
-                    attempt += 1
-            return
-
-        return wrapper
-
-    return decorator
 
 
 class Generator(ABC):

--- a/src/word_search_generator/core/word.py
+++ b/src/word_search_generator/core/word.py
@@ -1,6 +1,6 @@
 import colorsys
 import random
-from typing import Iterable, NamedTuple, TypedDict
+from typing import Iterable, NamedTuple, TypeAlias, TypedDict
 
 from rich.style import Style
 
@@ -92,6 +92,24 @@ class Word:
             if not validator.validate(self.text, placed_words=placed_words):
                 return False
         return True
+
+    @classmethod
+    def bulk_create(
+        cls,
+        words: str,
+        allowed_directions: DirectionSet,
+        secret: bool = False,
+        priority: int = 3,
+    ) -> "WordSet":
+        """
+        Returns a set[Word] for all unique words contained in a string delimited with
+        commas, spaces, or newlines.
+        """
+        return {
+            cls(w, secret, allowed_directions, priority)
+            for w in words.replace(",", "\t").split()
+            if w.strip()
+        }
 
     @property
     def lowercase(self) -> str:
@@ -311,3 +329,4 @@ class Word:
 
 
 NULL_WORD = Word("", True, allowed_directions=NDS.NONE, priority=999)
+WordSet: TypeAlias = set[Word]

--- a/src/word_search_generator/core/word.py
+++ b/src/word_search_generator/core/word.py
@@ -97,24 +97,6 @@ class Word:
                 return False
         return True
 
-    @classmethod
-    def bulk_create(
-        cls,
-        words: str,
-        allowed_directions: DirectionSet,
-        secret: bool = False,
-        priority: int = 3,
-    ) -> "WordSet":
-        """
-        Returns a set[Word] for all unique words contained in a string delimited with
-        commas, spaces, or newlines.
-        """
-        return {
-            cls(w, secret, allowed_directions, priority)
-            for w in words.replace(",", "\t").split()
-            if w.strip()
-        }
-
     @property
     def lowercase(self) -> str:
         """Return lowercase version of the word."""
@@ -335,3 +317,21 @@ class Word:
 NULL_WORD = Word("", True, allowed_directions=NDS.NONE, priority=999)
 WordSet: TypeAlias = set[Word]
 WordList: TypeAlias = list[Word]
+
+
+def make_many_words(
+    words: str,
+    allowed_directions: DirectionSet,
+    secret: bool = False,
+    priority: int = 3,
+) -> WordSet:
+    """
+    Returns a set[Word] for all unique words contained in a string delimited with
+    commas, spaces, or newlines.
+    """
+    # TODO in the Crossword branch, add the field for Mandatory
+    return {
+        Word(w, secret, allowed_directions, priority)
+        for w in words.replace(",", "\t").split()
+        if w.strip()
+    }

--- a/src/word_search_generator/core/word.py
+++ b/src/word_search_generator/core/word.py
@@ -15,6 +15,10 @@ class Position(NamedTuple):
     column: int | None
 
 
+PositionSet: TypeAlias = set[Position]
+PositionList: TypeAlias = list[Position]
+
+
 class Bearing(NamedTuple):
     position: Position
     direction: Direction
@@ -330,3 +334,4 @@ class Word:
 
 NULL_WORD = Word("", True, allowed_directions=NDS.NONE, priority=999)
 WordSet: TypeAlias = set[Word]
+WordList: TypeAlias = list[Word]

--- a/src/word_search_generator/utils.py
+++ b/src/word_search_generator/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 import random
-from typing import TYPE_CHECKING, TypeAlias, Sized, TypeVar, Iterable
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
 
 from .words import WORD_LIST
 
@@ -147,8 +147,8 @@ def get_answer_key_str(words: WordSet, bbox: BoundingBox) -> str:
     return ", ".join(get_answer_key_list(words, bbox))
 
 
-S = TypeVar("S", bound=Sized)
-T = TypeVar
+# set is NOT a superclass of frozenset, FYI
+S = TypeVar("S", bound=list[Any] | set[Any] | frozenset[Any])
 
 
 def limit(i: S, n: int) -> S:
@@ -157,7 +157,10 @@ def limit(i: S, n: int) -> S:
     """
     if len(i) <= n:
         return i
-    return type(i)(random.sample(i, n))
+    # type check ignored for now
+    # https://github.com/python/mypy/issues/13042
+    # https://stackoverflow.com/a/79037646/5544691
+    return type(i)(random.sample(list(i), n))  # type: ignore[return-value]
 
 
 def get_random_words(

--- a/src/word_search_generator/utils.py
+++ b/src/word_search_generator/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 import random
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias, Sized, TypeVar, Iterable
 
 from .words import WORD_LIST
 
@@ -147,6 +147,19 @@ def get_answer_key_str(words: WordSet, bbox: BoundingBox) -> str:
     return ", ".join(get_answer_key_list(words, bbox))
 
 
+S = TypeVar("S", bound=Sized)
+T = TypeVar
+
+
+def limit(i: S, n: int) -> S:
+    """
+    Limits the size of the input iterable to n.  Truncation is randomly chosen.
+    """
+    if len(i) <= n:
+        return i
+    return type(i)(random.sample(i, n))
+
+
 def get_random_words(
     n: int, max_length: int | None = None, min_length: int | None = None
 ) -> list[str]:
@@ -156,11 +169,11 @@ def get_random_words(
         max_length = 999
     if not min_length or min_length < 1:
         min_length = 1  # could just as easily be 0 or -23
-    words = (
-        WORD_LIST
-        if max_length == 999 and min_length == 1
-        else [word for word in WORD_LIST if min_length <= len(word) <= max_length]
+    return limit(
+        (
+            WORD_LIST
+            if max_length == 999 and min_length == 1
+            else [word for word in WORD_LIST if min_length <= len(word) <= max_length]
+        ),
+        n,
     )
-    if len(words) <= n:
-        return words  # prevent ValueError
-    return random.sample(words, n)

--- a/src/word_search_generator/utils.py
+++ b/src/word_search_generator/utils.py
@@ -150,11 +150,17 @@ def get_answer_key_str(words: WordSet, bbox: BoundingBox) -> str:
 def get_random_words(
     n: int, max_length: int | None = None, min_length: int | None = None
 ) -> list[str]:
-    """Return a list of random dictionary words."""
+    """Return a list of n random dictionary words matching the requested lengths.
+    If there are fewer matching words than n, return all matching words."""
     if not max_length or max_length < 1:
         max_length = 999
     if not min_length or min_length < 1:
-        min_length = 2  # can't have 1-char words
-    return random.sample(
-        [word for word in WORD_LIST if min_length <= len(word) <= max_length], n
+        min_length = 1  # could just as easily be 0 or -23
+    words = (
+        WORD_LIST
+        if max_length == 999 and min_length == 1
+        else [word for word in WORD_LIST if min_length <= len(word) <= max_length]
     )
+    if len(words) <= n:
+        return words  # prevent ValueError
+    return random.sample(words, n)

--- a/src/word_search_generator/utils.py
+++ b/src/word_search_generator/utils.py
@@ -47,7 +47,7 @@ def distance(x: int, y: int, ratio: float) -> float:
 
 def in_bounds(x: int, y: int, width: int, height: int) -> bool:
     """Validate position (x, y) is within the supplied bounds."""
-    return x >= 0 and x < width and y >= 0 and y < height
+    return 0 <= x < width and 0 <= y < height
 
 
 def find_bounding_box(
@@ -78,7 +78,7 @@ def find_bounding_box(
         if edge in r:
             max_x = size - 1 - i
             break
-    return ((min_x, min_y), (max_x, max_y))
+    return (min_x, min_y), (max_x, max_y)
 
 
 def stringify(puzzle: Puzzle, bbox: BoundingBox) -> str:
@@ -117,14 +117,14 @@ def get_answer_key_list(
     lowercase: bool = False,
     reversed_letters: bool = False,
 ) -> list[str]:
-    """Return a easy to read answer key for display/export. Resulting coordinates
+    """Return an easy-to-read answer key for display/export. Resulting coordinates
     will be offset by the supplied values. Used for masked puzzles.
 
     Args:
         words: A list of `Word` objects.
         bbox: Puzzle mask bounding box
         lowercase: Should words be lowercase. Defaults to False.
-        reversed_letters: Should words letters be reversed. Defaults to False.
+        reversed_letters: Should word's letters be reversed? Defaults to False.
 
     Returns:
         List of placed words with their placement information.
@@ -136,7 +136,7 @@ def get_answer_key_list(
 
 
 def get_answer_key_str(words: WordSet, bbox: BoundingBox) -> str:
-    """Return a easy to read answer key for display. Resulting coordinates
+    """Return an easy-to-read answer key for display. Resulting coordinates
     will be offset by the supplied values. Used for masked puzzles.
 
     Args:
@@ -147,8 +147,14 @@ def get_answer_key_str(words: WordSet, bbox: BoundingBox) -> str:
     return ", ".join(get_answer_key_list(words, bbox))
 
 
-def get_random_words(n: int, max_length: int | None = None) -> list[str]:
+def get_random_words(
+    n: int, max_length: int | None = None, min_length: int | None = None
+) -> list[str]:
     """Return a list of random dictionary words."""
-    if max_length:
-        return random.sample([word for word in WORD_LIST if len(word) <= max_length], n)
-    return random.sample(WORD_LIST, n)
+    if not max_length or max_length < 1:
+        max_length = 999
+    if not min_length or min_length < 1:
+        min_length = 2  # can't have 1-char words
+    return random.sample(
+        [word for word in WORD_LIST if min_length <= len(word) <= max_length], n
+    )

--- a/src/word_search_generator/utils.py
+++ b/src/word_search_generator/utils.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 import math
 import random
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
+from functools import wraps
 
 from .words import WORD_LIST
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .core.game import DirectionSet, Key, Puzzle, WordSet
+    from .core.game import DirectionSet, Key, WordSet
 
 
 BoundingBox: TypeAlias = tuple[tuple[int, int], tuple[int, int]]
+Puzzle: TypeAlias = tuple[int, int]
 
 
 def round_half_up(n: float, decimals: int = 0) -> float:
@@ -51,7 +53,7 @@ def in_bounds(x: int, y: int, width: int, height: int) -> bool:
 
 
 def find_bounding_box(
-    grid: list[list[str]],
+    grid: Puzzle,
     edge: str,
 ) -> BoundingBox:
     """Bounding box of the masked area as a rectangle defined
@@ -180,3 +182,26 @@ def get_random_words(
         ),
         n,
     )
+
+
+def retry(retries: int = 1000):
+    """Custom retry decorator for retrying a function `retries` times.
+
+    Args:
+        retries (int, optional): Retry attempts. Defaults to 1000.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            attempt = 0
+            while attempt < retries:
+                try:
+                    return func(*args, **kwargs)
+                except Exception:
+                    attempt += 1
+            return
+
+        return wrapper
+
+    return decorator

--- a/src/word_search_generator/word_search/_generator.py
+++ b/src/word_search_generator/word_search/_generator.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import random
 from typing import TYPE_CHECKING, TypeAlias
 
-from ..core.generator import Generator, WordFitError, retry
+from ..core.generator import Generator, WordFitError
 from ..core.word import Direction, Word
-from ..utils import in_bounds
+from ..utils import in_bounds, retry
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..core import GameType

--- a/src/word_search_generator/word_search/_generator.py
+++ b/src/word_search_generator/word_search/_generator.py
@@ -126,11 +126,8 @@ class WordSearchGenerator(Generator):
     def find_a_fit(self, word: Word, position: tuple[int, int]) -> Fit:
         """Look for random place in the puzzle where `word` fits."""
         fits: Fits = []
-        # check all directions for level
-        directions = secret_directions = self.game.directions
-        if hasattr(self.game, "secret_directions"):
-            secret_directions = self.game.secret_directions
-        for d in secret_directions if word.secret else directions:
+        # check all directions allowed for Word
+        for d in word.allowed_directions:
             coords = self.test_a_fit(word.text, position, d)
             if coords:
                 fits.append((Direction(d).name, coords))

--- a/src/word_search_generator/word_search/_generator.py
+++ b/src/word_search_generator/word_search/_generator.py
@@ -144,10 +144,7 @@ class WordSearchGenerator(Generator):
         Some words will be skipped if they don't fit."""
         # try to place each word on the puzzle
         placed_words: list[str] = []
-        hidden_words = [word for word in self.game.words if not word.secret]
-        secret_words = [word for word in self.game.words if word.secret]
-        # try to place each secret word on the puzzle first before hidden words
-        for word in hidden_words + secret_words:
+        for word in sorted(self.game.words):
             if self.game.validators and not word.validate(
                 self.game.validators, placed_words
             ):

--- a/src/word_search_generator/word_search/word_search.py
+++ b/src/word_search_generator/word_search/word_search.py
@@ -52,6 +52,7 @@ class WordSearch(Game):
         secret_words: str | None = None,
         secret_level: int | str | None = None,
         *,
+        preprocessed_words: WordSet | None = None,
         require_all_words: bool = False,
         generator: Generator | None = None,
         formatter: Formatter | None = None,
@@ -78,18 +79,15 @@ class WordSearch(Game):
                 word validation. Defaults to `DEFAULT_VALIDATORS`.
         """
         # determine valid word directions
-        self._secret_directions: DirectionSet = (
-            self.validate_level(secret_level)
-            if secret_level
-            else (self.validate_level(level) if level else self.validate_level(2))
-        )
+        dirs = self.validate_level(level, self.DEFAULT_DIRECTIONS)
+        self._secret_directions: DirectionSet = self.validate_level(secret_level, dirs)
 
         # setup words
-        word_set = set()
+        word_set = set() if preprocessed_words is None else preprocessed_words
         if words:
-            word_set.update(self._process_input(words))
+            word_set |= self._process_input(words, False, dirs)
         if secret_words:
-            word_set.update(self._process_input(secret_words, secret=True))
+            word_set |= self._process_input(secret_words, True, self.secret_directions)
 
         super().__init__(
             words=word_set,

--- a/src/word_search_generator/word_search/word_search.py
+++ b/src/word_search_generator/word_search/word_search.py
@@ -29,12 +29,6 @@ from ._generator import WordSearchGenerator
 class WordSearch(Game):
     """This class represents a WordSearch object."""
 
-    MIN_PUZZLE_SIZE = 5
-    MAX_PUZZLE_SIZE = 50
-    MIN_PUZZLE_WORDS = 1
-    MAX_PUZZLE_WORDS = 100
-    MAX_FIT_TRIES = 1000
-
     DEFAULT_GENERATOR = WordSearchGenerator()
     DEFAULT_FORMATTER = WordSearchFormatter()
     DEFAULT_VALIDATORS = [

--- a/src/word_search_generator/word_search/word_search.py
+++ b/src/word_search_generator/word_search/word_search.py
@@ -70,8 +70,10 @@ class WordSearch(Game):
                 word list. Defaults to None.
             secret_level: Difficulty level or potential word directions for
                 'secret' words. Defaults to None.
-            require_all_words: Raises an error when `generator` cannot place all of
-                the words.  Secret words are not included in this check.
+            preprocessed_words: A set of Words that have already been created.
+                Used when WordSearch is used as a dependency for something else.
+            require_all_words: Raises an error when `generator` cannot place all
+                 the words.  Secret words are not included in this check.
             generator: Puzzle generator. Defaults to None.
             formatter: Game formatter. Defaults to None.
             validators: An iterable of validators that puzzle words will be checked

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,10 @@ def secret_words():
 
 @pytest.fixture
 def preprocessed_words():
-    return {Word("Zebra", False, {Direction.NW}, 4, "A striped horse.")}
+    return {
+        Word("Zebra", False, {Direction.NW}, 1, "A striped horse."),
+        Word("llama", True, {Direction.W}, 1, "likely to spit on you"),
+    }
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def base_game(words, empty_generator, empty_formatter, empty_validator):
         words=words,
         generator=empty_generator,
         formatter=empty_formatter,
-        validators=[empty_formatter],
+        validators=[empty_validator],
     )
 
 
@@ -81,6 +81,11 @@ def words():
 def secret_words():
     # "tortoise" not included in because it is 8 characters long (everything else at 6)
     return "rabbit, mule, bunny, ram, kitten, puppy, foal"
+
+
+@pytest.fixture
+def preprocessed_words():
+    return {Word("Zebra", False, {Direction.NW}, 4, "A striped horse.")}
 
 
 @pytest.fixture

--- a/tests/test_Game.py
+++ b/tests/test_Game.py
@@ -152,7 +152,7 @@ def test_cleanup_input(base_game: Game, words: str, ct: int):
 
 def test_invalid_level_direction_type(base_game: Game):
     with pytest.raises(TypeError):
-        base_game.validate_level(None)
+        base_game.validate_level(base_game)
 
 
 def test_missing_generator():

--- a/tests/test_Word.py
+++ b/tests/test_Word.py
@@ -1,4 +1,4 @@
-from word_search_generator.core.word import Direction, Position, Word
+from word_search_generator.core.word import Bearing, Direction, Position, Word
 
 
 def test_empty_start_row():
@@ -75,3 +75,18 @@ def test_word_bool_true():
 def test_word_bool_false():
     w = Word("")
     assert not w
+
+
+def test_set_bearing():
+    w = Word("test")
+    w.bearing = Bearing(Position(3, 2), Direction.S)
+    assert w.direction == Direction.S
+    assert w.position.row == 3
+
+
+def test_read_bearing():
+    w = Word("test")
+    w.position = Position(11, 18)
+    assert w.bearing is None
+    w.direction = Direction.W
+    assert hasattr(w.bearing, "position")

--- a/tests/test_WordSearch.py
+++ b/tests/test_WordSearch.py
@@ -433,3 +433,12 @@ def test_no_words_to_generate(ws: WordSearch):
     ws._words = set()
     with pytest.raises(EmptyWordlistError):
         ws.generate()
+
+
+def test_word_search_too_many_words(words, preprocessed_words):
+    class ShortWS(WordSearch):
+        MAX_PUZZLE_WORDS = 7
+
+    ws = ShortWS(level="", secret_words=words, preprocessed_words=preprocessed_words)
+    assert len(ws.placed_words) == 7
+    assert "zebra" in ",".join(w.lowercase for w in ws.placed_hidden_words)


### PR DESCRIPTION
Should finish off #51.  

Few things I thought of to check before merging.

1. Should I edit `Word.__lt__` at all?
2. `WordSearch.__init__` is rather messy, as the secret words are formed _before_ the call to `super().__init__`.
3. Updating WordSearchGenerator to use priorities & direction choices stored in the Word was surprisingly straightforward once I found where to make the change and did the prep work.