### PR TITLE
Add --no-sort-words option

### DIFF
--- a/src/word_search_generator/cli.py
+++ b/src/word_search_generator/cli.py
@@ -138,6 +138,11 @@ puzzle words can go. See valid arguments above.",
         help="Disable default word validators.",
     )
     parser.add_argument(
+        "--no-sort-words",
+        action="store_true",
+        help="Display words in original order rather than sorted alphabetically.",
+    )
+    parser.add_argument(
         "-o",
         "--output",
         type=Path,
@@ -334,6 +339,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             solution=args.cheat,
             lowercase=args.lowercase,
             hide_key=args.hide_key,
+            no_sort_words=args.no_sort_words,
         )
         print(f"Puzzle saved: {foutput}")
 
@@ -343,6 +349,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             lowercase=args.lowercase,
             reversed_letters=not args.cheat,
             hide_key=args.hide_key,
+            no_sort_words=args.no_sort_words,
         )
 
     return 0

--- a/src/word_search_generator/word_search/word_search.py
+++ b/src/word_search_generator/word_search/word_search.py
@@ -182,6 +182,7 @@ class WordSearch(Game):
         lowercase: bool = False,
         hide_key: bool = False,
         reversed_letters: bool = False,
+        no_sort_words: bool = False,
     ):
         return super().show(
             solution=solution,
@@ -189,6 +190,7 @@ class WordSearch(Game):
             lowercase=lowercase,
             hide_key=hide_key,
             reversed_letters=reversed_letters,
+            no_sort_words=no_sort_words,
         )
 
     def save(
@@ -198,6 +200,7 @@ class WordSearch(Game):
         solution: bool = False,
         lowercase: bool = False,
         hide_key: bool = False,
+        no_sort_words: bool = False,
         *args,
         **kwargs,
     ) -> str:
@@ -207,6 +210,7 @@ class WordSearch(Game):
             solution=solution,
             lowercase=lowercase,
             hide_key=hide_key,
+            no_sort_words=no_sort_words,
         )
 
     # *************************************************************** #

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,3 +238,11 @@ def test_input_file(tmp_path: Path):
     file_to_read.write_text("dog, pig\nmoose,horse,cat,    mouse, newt\ngoose")
     result = subprocess.run(f"word-search -i {file_to_read.absolute()}", shell=True)
     assert result.returncode == 0
+
+
+def test_no_sort_words():
+    """Test that --no-sort-words preserves the original word order."""
+    result = subprocess.run("word-search hello world test --no-sort-words", shell=True)
+    assert result.returncode == 0
+
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,7 +242,20 @@ def test_input_file(tmp_path: Path):
 
 def test_no_sort_words():
     """Test that --no-sort-words preserves the original word order."""
-    result = subprocess.run("word-search hello world test --no-sort-words", shell=True)
+    words = "hello world test"
+    result = subprocess.run(
+        f"word-search {words} --no-sort-words",
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
     assert result.returncode == 0
+    # find the line with the word list
+    for line in result.stdout.splitlines():
+        if line.startswith("Word List:"):
+            # extract the words from the line
+            found_words = line.replace("Word List: ", "").split(", ")
+            assert found_words == words.split()
+            break
 
 


### PR DESCRIPTION
Adds a command-line option (`--no-sort-words`) to display the word list in its original order instead of sorting it alphabetically. This provides users with more control over the output format.

The new flag is supported for all output types, including console, CSV, JSON, and PDF.